### PR TITLE
Fix variant `mbind`

### DIFF
--- a/include/reaver/configuration/configuration.h
+++ b/include/reaver/configuration/configuration.h
@@ -34,6 +34,7 @@
 #include "../overloads.h"
 #include "../logic.h"
 #include "../void_t.h"
+#include "../subset.h"
 
 namespace reaver { inline namespace _v1
 {
@@ -200,78 +201,40 @@ namespace reaver { inline namespace _v1
         std::unordered_map<boost::typeindex::type_index, boost::any, boost::hash<boost::typeindex::type_index>> _map;
     };
 
-    namespace _detail
-    {
-        template<typename Checked, typename Set>
-        struct _is_a_subset : public std::false_type
-        {
-        };
-
-        template<typename... Set>
-        struct _is_a_subset<std::tuple<>, std::tuple<Set...>> : public std::true_type
-        {
-        };
-
-        template<typename... Checked>
-        struct _is_a_subset<std::tuple<Checked...>, std::tuple<>> : public std::false_type
-        {
-        };
-
-        template<typename T>
-        struct _is_a_subset<std::tuple<T>, std::tuple<T>> : public std::true_type
-        {
-        };
-
-        template<typename T, typename... Others>
-        struct _is_a_subset<std::tuple<T>, std::tuple<T, Others...>> : public std::true_type
-        {
-        };
-
-        template<typename T, typename Head, typename... Tail>
-        struct _is_a_subset<std::tuple<T>, std::tuple<Head, Tail...>> : public _is_a_subset<std::tuple<T>, std::tuple<Tail...>>
-        {
-        };
-
-        template<typename... Checked, typename... Set>
-        struct _is_a_subset<std::tuple<Checked...>, std::tuple<Set...>> : public all_of<_is_a_subset<std::tuple<Checked>, std::tuple<Set...>>::value...>
-        {
-        };
-    }
-
     template<typename... Allowed>
     class bound_configuration : public configuration
     {
     private:
-        template<typename... Other, typename std::enable_if<_detail::_is_a_subset<std::tuple<Other...>, std::tuple<Allowed...>>::value, int>::type = 0>
+        template<typename... Other, typename std::enable_if<is_subset<tpl::vector<Other...>, tpl::vector<Allowed...>>::value, int>::type = 0>
         bound_configuration(const bound_configuration<Other...> & other) : configuration{ other }
         {
         }
 
-        template<typename... Other, typename std::enable_if<_detail::_is_a_subset<std::tuple<Other...>, std::tuple<Allowed...>>::value, int>::type = 0>
+        template<typename... Other, typename std::enable_if<is_subset<tpl::vector<Other...>, tpl::vector<Allowed...>>::value, int>::type = 0>
         bound_configuration(bound_configuration<Other...> && other) : configuration{ std::move(other) }
         {
         }
 
     public:
         template<typename... Other, typename std::enable_if<
-            !_detail::_is_a_subset<std::tuple<Allowed...>, std::tuple<Other...>>::value &&
-            !_detail::_is_a_subset<std::tuple<Other...>, std::tuple<Allowed...>>::value,
+            !is_subset<tpl::vector<Allowed...>, tpl::vector<Other...>>::value &&
+            !is_subset<tpl::vector<Other...>, tpl::vector<Allowed...>>::value,
         int>::type = 0>
         bound_configuration(const bound_configuration<Other...> & other) = delete;
 
         template<typename... Other, typename std::enable_if<
-            !_detail::_is_a_subset<std::tuple<Allowed...>, std::tuple<Other...>>::value &&
-            !_detail::_is_a_subset<std::tuple<Other...>, std::tuple<Allowed...>>::value,
+            !is_subset<tpl::vector<Allowed...>, tpl::vector<Other...>>::value &&
+            !is_subset<tpl::vector<Other...>, tpl::vector<Allowed...>>::value,
         int>::type = 0>
         bound_configuration(bound_configuration<Other...> && other) = delete;
 
-        template<typename... Other, typename std::enable_if<_detail::_is_a_subset<std::tuple<Allowed...>, std::tuple<Other...>>::value, int>::type = 0>
+        template<typename... Other, typename std::enable_if<is_subset<tpl::vector<Allowed...>, tpl::vector<Other...>>::value, int>::type = 0>
         bound_configuration(const bound_configuration<Other...> & other)
         {
             swallow{ set<Allowed>(other.template get<Allowed>())... };
         }
 
-        template<typename... Other, typename std::enable_if<_detail::_is_a_subset<std::tuple<Allowed...>, std::tuple<Other...>>::value, int>::type = 0>
+        template<typename... Other, typename std::enable_if<is_subset<tpl::vector<Allowed...>, tpl::vector<Other...>>::value, int>::type = 0>
         bound_configuration(bound_configuration<Other...> && other)
         {
             swallow{ set<Allowed>(std::move(other.template get<Allowed>()))... };

--- a/include/reaver/subset.h
+++ b/include/reaver/subset.h
@@ -1,0 +1,64 @@
+/**
+ * Reaver Library Licence
+ *
+ * Copyright © 2016 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#include <type_traits>
+
+#include "tpl/vector.h"
+
+namespace reaver { inline namespace _v1
+{
+    template<typename Checked, typename Set>
+    struct is_subset : public std::false_type
+    {
+    };
+
+    template<typename... Set>
+    struct is_subset<tpl::vector<>, tpl::vector<Set...>> : public std::true_type
+    {
+    };
+
+    template<typename... Checked>
+    struct is_subset<tpl::vector<Checked...>, tpl::vector<>> : public std::false_type
+    {
+    };
+
+    template<typename T>
+    struct is_subset<tpl::vector<T>, tpl::vector<T>> : public std::true_type
+    {
+    };
+
+    template<typename T, typename... Others>
+    struct is_subset<tpl::vector<T>, tpl::vector<T, Others...>> : public std::true_type
+    {
+    };
+
+    template<typename T, typename Head, typename... Tail>
+    struct is_subset<tpl::vector<T>, tpl::vector<Head, Tail...>> : public is_subset<tpl::vector<T>, tpl::vector<Tail...>>
+    {
+    };
+
+    template<typename... Checked, typename... Set>
+    struct is_subset<tpl::vector<Checked...>, tpl::vector<Set...>> : public all_of<is_subset<tpl::vector<Checked>, tpl::vector<Set...>>::value...>
+    {
+    };
+}}
+

--- a/include/reaver/tpl/map.h
+++ b/include/reaver/tpl/map.h
@@ -22,17 +22,25 @@
 
 #pragma once
 
+#include "vector.h"
+
 namespace reaver
 {
     namespace tpl { inline namespace _v1
     {
         namespace _detail
         {
-            template<typename TypeVector, typename Function>
+            template<typename TypeVector, template<typename...> typename Function>
             struct _map;
+
+            template<typename... Ts, template<typename...> typename Function>
+            struct _map<vector<Ts...>, Function>
+            {
+                using type = vector<Function<Ts>...>;
+            };
         }
 
-        template<typename Vector, typename Function>
+        template<typename Vector, template<typename...> typename Function>
         using map = typename _detail::_map<Vector, Function>::type;
     }}
 }

--- a/tests/variant.cpp
+++ b/tests/variant.cpp
@@ -445,6 +445,8 @@ MAYFLY_ADD_TESTCASE("n-ary visitation", []()
         MAYFLY_CHECK(test::reaver::get<int>(test::reaver::visit([](auto first, auto second, auto third) { return first; }, v1, v2, v3)) == 1);
         MAYFLY_CHECK(test::reaver::get<float>(test::reaver::visit([](auto first, auto second, auto third) { return second; }, v1, v2, v3)) == 2.f);
         MAYFLY_CHECK(test::reaver::get<std::string>(test::reaver::visit([](auto first, auto second, auto third) { return third; }, v1, v2, v3)) == "abc");
+
+        MAYFLY_CHECK_THROWS_TYPE(test::reaver::invalid_variant_get, test::reaver::get<float>(test::reaver::visit([](auto first, auto second) { return first; }, v1, v2)));
     }
 
     {
@@ -456,6 +458,8 @@ MAYFLY_ADD_TESTCASE("n-ary visitation", []()
         MAYFLY_CHECK(test::reaver::get<int>(test::reaver::visit([](auto first, auto second, auto third) { return first; }, v1, v2, v3)) == 1);
         MAYFLY_CHECK(test::reaver::get<float>(test::reaver::visit([](auto first, auto second, auto third) { return second; }, v1, v2, v3)) == 2.f);
         MAYFLY_CHECK(test::reaver::get<std::string>(test::reaver::visit([](auto first, auto second, auto third) { return third; }, v1, v2, v3)) == "abc");
+
+        MAYFLY_CHECK_THROWS_TYPE(test::reaver::invalid_variant_get, test::reaver::get<float>(test::reaver::visit([](auto first, auto second) { return first; }, v1, v2)));
     }
 
     {
@@ -472,6 +476,8 @@ MAYFLY_ADD_TESTCASE("n-ary visitation", []()
 
         v3 = "abc";
         MAYFLY_CHECK(test::reaver::get<std::string>(test::reaver::visit([](auto first, auto second, auto third) { return third; }, std::move(v1), std::move(v2), std::move(v3))) == "abc");
+
+        MAYFLY_CHECK_THROWS_TYPE(test::reaver::invalid_variant_get, test::reaver::get<float>(test::reaver::visit([](auto first, auto second) { return first; }, v1, v2)));
     }
 });
 


### PR DESCRIPTION
`variant`'s `mbind` was horrendously broken; it worked by accident, because `std::string` can actually be constructed from integers. The tests didn't explode due to some magic related to that; now a get for a wrong type properly compiles (and just throws at runtime).

I'm not actually sure why it fully worked before. Oh bother.