### PR TITLE
future: promise-like helper for manual future fulfillment; monadic interface.

### DIFF
--- a/include/reaver/future.h
+++ b/include/reaver/future.h
@@ -901,7 +901,7 @@ namespace reaver { inline namespace _v1
         template<typename F>
         auto then(std::shared_ptr<executor> sched, F && f)
         {
-            return _detail::_unwrap([sched = sched]{ return sched; }, then(do_not_unwrap, std::move(sched), std::forward<F>(f)));
+            return _detail::_unwrap([sched = sched]{ return sched; }, then(do_not_unwrap, sched, std::forward<F>(f)));
         }
 
         template<typename F>
@@ -918,7 +918,7 @@ namespace reaver { inline namespace _v1
         template<typename F>
         auto on_error(std::shared_ptr<executor> sched, F && f)
         {
-            return _detail::_unwrap([sched = sched]{ return sched; }, on_error(do_not_unwrap, std::move(sched), std::forward<F>(f)));
+            return _detail::_unwrap([sched = sched]{ return sched; }, on_error(do_not_unwrap, sched, std::forward<F>(f)));
         }
 
         template<typename F>
@@ -1063,7 +1063,7 @@ namespace reaver { inline namespace _v1
         template<typename F>
         auto then(std::shared_ptr<executor> sched, F && f)
         {
-            return _detail::_unwrap([sched = sched]{ return sched; }, then(do_not_unwrap, std::move(sched), std::forward<F>(f)));
+            return _detail::_unwrap([sched = sched]{ return sched; }, then(do_not_unwrap, sched, std::forward<F>(f)));
         }
 
         template<typename F>
@@ -1080,7 +1080,7 @@ namespace reaver { inline namespace _v1
         template<typename F>
         auto on_error(std::shared_ptr<executor> sched, F && f)
         {
-            return _detail::_unwrap([sched = sched]{ return sched; }, on_error(do_not_unwrap, std::move(sched), std::forward<F>(f)));
+            return _detail::_unwrap([sched = sched]{ return sched; }, on_error(do_not_unwrap, sched, std::forward<F>(f)));
         }
 
         template<typename F>

--- a/include/reaver/future.h
+++ b/include/reaver/future.h
@@ -1480,12 +1480,6 @@ namespace reaver { inline namespace _v1
         return when_all(std::move(sched), exception_policy::aggregate, futures);
     }
 
-    template<typename T, typename F>
-    auto fmap(future<T> fut, F && f)
-    {
-        return std::move(fut).then(std::forward<F>(f));
-    }
-
     namespace _detail
     {
         // I wish C++ just allowed generalized lambda captures on packs

--- a/tests/future.cpp
+++ b/tests/future.cpp
@@ -735,5 +735,38 @@ MAYFLY_ADD_TESTCASE("void join", []()
     }
 });
 
+MAYFLY_ADD_TESTCASE("unwrap and not", []()
+{
+    auto exec = test::reaver::make_executor<trivial_executor>();
+
+    {
+        auto fut1 = test::reaver::make_ready_future(123);
+        auto fut2 = fut1.then(exec, [](auto v){ return test::reaver::make_ready_future(v * 2); });
+
+        MAYFLY_REQUIRE(fut2.try_get() == 246);
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future(123);
+        auto fut2 = fut1.then(test::reaver::do_not_unwrap, exec, [](auto v){ return test::reaver::make_ready_future(v * 2); });
+
+        MAYFLY_REQUIRE(fut2.try_get()->try_get() == 246);
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future();
+        auto fut2 = fut1.then(exec, [](){ return test::reaver::make_ready_future(); });
+
+        MAYFLY_REQUIRE(fut2.try_get());
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future();
+        auto fut2 = fut1.then(test::reaver::do_not_unwrap, exec, [](){ return test::reaver::make_ready_future(); });
+
+        MAYFLY_REQUIRE(fut2.try_get()->try_get());
+    }
+});
+
 MAYFLY_END_SUITE;
 

--- a/tests/future.cpp
+++ b/tests/future.cpp
@@ -572,5 +572,32 @@ MAYFLY_ADD_TESTCASE("vector exception propagation", []()
 
 MAYFLY_END_SUITE;
 
+MAYFLY_ADD_TESTCASE("manual promise", []()
+{
+    {
+        auto pair = test::reaver::make_promise<int>();
+        MAYFLY_REQUIRE(!pair.future.try_get());
+
+        pair.promise.set(1);
+        MAYFLY_REQUIRE(pair.future.try_get() == 1);
+    }
+
+    {
+        auto pair = test::reaver::make_promise<void>();
+        MAYFLY_REQUIRE(!pair.future.try_get());
+
+        pair.promise.set();
+        MAYFLY_REQUIRE(pair.future.try_get() == 1);
+    }
+
+    {
+        auto pair = test::reaver::make_promise<void>();
+        MAYFLY_REQUIRE(!pair.future.try_get());
+
+        pair.promise.set(std::make_exception_ptr(1));
+        MAYFLY_REQUIRE_THROWS_TYPE(int, pair.future.try_get());
+    }
+});
+
 MAYFLY_END_SUITE;
 

--- a/tests/future.cpp
+++ b/tests/future.cpp
@@ -574,11 +574,13 @@ MAYFLY_END_SUITE;
 
 MAYFLY_ADD_TESTCASE("manual promise", []()
 {
+    auto exec = test::reaver::make_executor<trivial_executor>();
+
     {
         auto pair = test::reaver::make_promise<int>();
         MAYFLY_REQUIRE(!pair.future.try_get());
 
-        pair.promise.set(1);
+        pair.promise.set(exec, 1);
         MAYFLY_REQUIRE(pair.future.try_get() == 1);
     }
 
@@ -586,7 +588,7 @@ MAYFLY_ADD_TESTCASE("manual promise", []()
         auto pair = test::reaver::make_promise<void>();
         MAYFLY_REQUIRE(!pair.future.try_get());
 
-        pair.promise.set();
+        pair.promise.set(exec);
         MAYFLY_REQUIRE(pair.future.try_get() == 1);
     }
 
@@ -594,8 +596,142 @@ MAYFLY_ADD_TESTCASE("manual promise", []()
         auto pair = test::reaver::make_promise<void>();
         MAYFLY_REQUIRE(!pair.future.try_get());
 
-        pair.promise.set(std::make_exception_ptr(1));
+        pair.promise.set(exec, std::make_exception_ptr(1));
         MAYFLY_REQUIRE_THROWS_TYPE(int, pair.future.try_get());
+    }
+});
+
+MAYFLY_ADD_TESTCASE("join", []()
+{
+    {
+        auto pair1 = test::reaver::make_promise<int>();
+        auto pair2 = test::reaver::package([&]{ return std::move(pair1.future); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec, 123);
+        MAYFLY_REQUIRE(fut.try_get() == 123);
+    }
+
+    {
+        auto pair1 = test::reaver::make_promise<int>();
+        auto pair2 = test::reaver::package([&]{ return std::move(pair1.future); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec, 123);
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(fut.try_get() == 123);
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future(123);
+        auto pair2 = test::reaver::package([&]{ return std::move(fut1); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(fut.try_get() == 123);
+    }
+
+    {
+        auto pair1 = test::reaver::make_promise<int>();
+        auto fut2 = test::reaver::make_ready_future(std::move(pair1.future));
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, fut2);
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec, 123);
+        MAYFLY_REQUIRE(fut.try_get() == 123);
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future(123);
+        auto fut2 = test::reaver::make_ready_future(std::move(fut1));
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, fut2);
+        MAYFLY_REQUIRE(fut.try_get() == 123);
+    }
+});
+
+MAYFLY_ADD_TESTCASE("void join", []()
+{
+    {
+        auto pair1 = test::reaver::make_promise<void>();
+        auto pair2 = test::reaver::package([&]{ return std::move(pair1.future); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec);
+        MAYFLY_REQUIRE(fut.try_get());
+    }
+
+    {
+        auto pair1 = test::reaver::make_promise<void>();
+        auto pair2 = test::reaver::package([&]{ return std::move(pair1.future); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec);
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(fut.try_get());
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future();
+        auto pair2 = test::reaver::package([&]{ return std::move(fut1); });
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, pair2.future);
+        MAYFLY_REQUIRE(!fut.try_get());
+        exec->push([exec, task = std::move(pair2.packaged_task)](){ task(exec); });
+        MAYFLY_REQUIRE(fut.try_get());
+    }
+
+    {
+        auto pair1 = test::reaver::make_promise<void>();
+        auto fut2 = test::reaver::make_ready_future(std::move(pair1.future));
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, fut2);
+        MAYFLY_REQUIRE(!fut.try_get());
+        pair1.promise.set(exec);
+        MAYFLY_REQUIRE(fut.try_get());
+    }
+
+    {
+        auto fut1 = test::reaver::make_ready_future();
+        auto fut2 = test::reaver::make_ready_future(std::move(fut1));
+
+        auto exec = test::reaver::make_executor<trivial_executor>();
+
+        auto fut = test::reaver::join(exec, fut2);
+        MAYFLY_REQUIRE(fut.try_get());
     }
 });
 


### PR DESCRIPTION
Accidentally this PR will also include the monadic interface, and `.then()` that behaves like `mbind` by default.