### PR TITLE
typeclass: initial macro-based version.

### DIFF
--- a/include/reaver/function_traits.h
+++ b/include/reaver/function_traits.h
@@ -1,0 +1,112 @@
+/**
+ * Reaver Library Licence
+ *
+ * Copyright © 2017 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#pragma once
+
+namespace reaver
+{
+inline namespace _v1
+{
+    enum class ref_qualifier
+    {
+        none,
+        lvalue,
+        rvalue
+    };
+
+    template<typename, bool is_const = false, bool is_volatile = false, ref_qualifier = ref_qualifier::none>
+    struct function_traits;
+
+    template<typename Ret, typename... Args, bool IsConst, bool IsVolatile, ref_qualifier RefQualifier>
+    struct function_traits<Ret(Args...), IsConst, IsVolatile, RefQualifier>
+    {
+        using return_type = Ret;
+        constexpr static bool is_const = IsConst;
+        constexpr static bool is_volatile = IsVolatile;
+        constexpr static ref_qualifier reference_qualifier = RefQualifier;
+
+        template<template<typename...> typename Template, typename... AdditionalArguments>
+        using explode = Template<AdditionalArguments..., Ret, Args...>;
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const> : function_traits<Ret(Args...), true, false>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) volatile> : function_traits<Ret(Args...), false, true>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const volatile> : function_traits<Ret(Args...), true, true>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) &> : function_traits<Ret(Args...), true, false, ref_qualifier::lvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const &> : function_traits<Ret(Args...), true, false, ref_qualifier::lvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) volatile &> : function_traits<Ret(Args...), false, true, ref_qualifier::lvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const volatile &> : function_traits<Ret(Args...), true, true, ref_qualifier::lvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) &&> : function_traits<Ret(Args...), true, false, ref_qualifier::rvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const &&> : function_traits<Ret(Args...), true, false, ref_qualifier::rvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) volatile &&> : function_traits<Ret(Args...), false, true, ref_qualifier::rvalue>
+    {
+    };
+
+    template<typename Ret, typename... Args>
+    struct function_traits<Ret(Args...) const volatile &&> : function_traits<Ret(Args...), true, true, ref_qualifier::rvalue>
+    {
+    };
+
+    template<typename F>
+    using return_type = typename function_traits<F>::return_type;
+
+    template<typename F, template<typename...> typename Template, typename... AdditionalArguments>
+    using explode = typename function_traits<F>::template explode<Template, AdditionalArguments...>;
+}
+}

--- a/include/reaver/typeclass/typeclass.h
+++ b/include/reaver/typeclass/typeclass.h
@@ -1,0 +1,384 @@
+/**
+ * Reaver Library Licence
+ *
+ * Copyright © 2017 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
+
+#include "../function_traits.h"
+
+namespace reaver
+{
+inline namespace _v1
+{
+    template<typename Typeclass, typename T, typename = void>
+    struct typeclass_trait;
+
+    template<typename Typeclass, typename T>
+    struct typeclass_trait<Typeclass, T, typename std::enable_if<std::is_class<T>::value>::type>
+    {
+        using type = typename T::template instance<Typeclass, T>;
+    };
+
+    template<typename Typeclass, typename T>
+    struct typeclass_trait<Typeclass, T, typename std::enable_if<!std::is_class<T>::value>::type>
+    {
+        using type = typename Typeclass::template instance<Typeclass, T>;
+    };
+
+    template<typename Typeclass, typename T>
+    using tc_instance = typename typeclass_trait<Typeclass, T>::type;
+
+#define TYPECLASS_INTERNAL_REAVER_NAMESPACE ::reaver
+
+#define INSTANCE_TEMPLATE_HELPER                                                                                                                               \
+    template<typename Typeclass, typename Class>                                                                                                               \
+    struct typeclass_instance_helper
+
+#define TYPECLASS_INSTANCE(...)                                                                                                                                \
+    template<typename _typeclass, __VA_ARGS__>                                                                                                                 \
+    struct instance
+
+#define TYPECLASS_INSTANCE_TEMPLATE(template_decl, template_args, class)                                                                                       \
+    template<typename _typeclass, ONLY template_decl>                                                                                                          \
+    struct instance : typeclass_instance_helper<_typeclass, ONLY template_args>                                                                                \
+    {                                                                                                                                                          \
+    }
+
+#define DEFAULT_INSTANCE(typeclass, ...)                                                                                                                       \
+    template<typename __VA_ARGS__>                                                                                                                             \
+    struct typeclass::instance<typeclass, __VA_ARGS__>
+
+#define DEFAULT_INSTANCE_TEMPLATE(template_decl, template_args, typeclass, ...)                                                                                \
+    INSTANCE_TEMPLATE_HELPER;                                                                                                                                  \
+    template<ONLY template_decl>                                                                                                                               \
+    template<typename __VA_ARGS__>                                                                                                                             \
+    struct typeclass<ONLY template_args>::instance<typeclass<ONLY template_args>, __VA_ARGS__>
+
+#define SPECIAL_INSTANCE(typeclass, class)                                                                                                                     \
+    template<>                                                                                                                                                 \
+    struct typeclass::instance<typeclass, class>
+
+#define INSTANCE(typeclass, class)                                                                                                                             \
+    template<>                                                                                                                                                 \
+    struct class ::instance<typeclass, class> : public typeclass::instance<typeclass, class>
+
+#define INSTANCE_TEMPLATE(template_decl, template_args, typeclass, class)                                                                                      \
+    INSTANCE_TEMPLATE_HELPER;                                                                                                                                  \
+    template<ONLY template_decl>                                                                                                                               \
+    struct typeclass_instance_helper<typeclass<ONLY template_args>, class>                                                                                     \
+        : public typeclass<ONLY template_args>::template instance<typeclass<ONLY template_args>, class>
+
+    template<typename T>
+    struct virtual_dtor
+    {
+        virtual ~virtual_dtor() = default;
+    };
+
+    template<typename T>
+    struct typeclass_provide_data_member
+    {
+        T t = {};
+    };
+
+#define CONCAT(X, Y) X##Y
+#define CONCAT3(X, Y, Z) X##Y##Z
+
+#define TYPECLASS_PREPARE_MIXINS(x, typeclass_name, memfn_name)                                                                                                \
+    template<typename ReturnType, typename... Args>                                                                                                            \
+    struct CONCAT3(typeclass_name, _typeclass_base_provide_, memfn_name)                                                                                       \
+        : protected TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<class typeclass_base_provide_>                                                           \
+    {                                                                                                                                                          \
+        virtual ReturnType memfn_name(Args...) = 0;                                                                                                            \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template<typename Typeclass, typename T, typename ReturnType, typename... Args>                                                                            \
+    struct CONCAT3(typeclass_name, _typeclass_impl_provide_, memfn_name)                                                                                       \
+        : virtual CONCAT3(typeclass_name, _typeclass_base_provide_, memfn_name)<ReturnType, Args...>,                                                          \
+          protected virtual TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<T>                                                              \
+    {                                                                                                                                                          \
+        CONCAT3(typeclass_name, _typeclass_impl_provide_, memfn_name)                                                                                          \
+        (const T & t) : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<T>{ t }                                                             \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+                                                                                                                                                               \
+        virtual ReturnType memfn_name(Args... args) override                                                                                                   \
+        {                                                                                                                                                      \
+            return Typeclass::memfn_name(TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<T>::t, std::forward<Args>(args)...);               \
+        }                                                                                                                                                      \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template<typename Typeclass, typename ReturnType, typename... Args>                                                                                        \
+    struct CONCAT3(typeclass_name, _typeclass_provide_, memfn_name) : protected TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<class typeclass_provide_>    \
+    {                                                                                                                                                          \
+        template<typename T>                                                                                                                                   \
+        static ReturnType memfn_name(T & t, Args... args)                                                                                                      \
+        {                                                                                                                                                      \
+            return TYPECLASS_INTERNAL_REAVER_NAMESPACE::tc_instance<Typeclass, T>::memfn_name(t, std::forward<Args>(args)...);                                 \
+        }                                                                                                                                                      \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template<typename Typeclass, typename ReturnType, typename... Args>                                                                                        \
+    struct CONCAT3(typeclass_name, _typeclass_erased_provide_, memfn_name)                                                                                     \
+        : protected TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<class typeclass_erased_provide_>,                                                        \
+          protected virtual TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typename Typeclass::_base>>                     \
+    {                                                                                                                                                          \
+        ReturnType memfn_name(Args... args)                                                                                                                    \
+        {                                                                                                                                                      \
+            return TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typename Typeclass::_base>>::t->memfn_name(              \
+                std::forward<Args>(args)...);                                                                                                                  \
+        }                                                                                                                                                      \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template<typename Typeclass, typename ReturnType, typename... Args>                                                                                        \
+    struct CONCAT3(typeclass_name, _typeclass_erased_instance_provide_, memfn_name)                                                                            \
+    {                                                                                                                                                          \
+        static ReturnType memfn_name(typename Typeclass::erased_ref & t, Args... args)                                                                         \
+        {                                                                                                                                                      \
+            return t.memfn_name(std::forward<Args>(args)...);                                                                                                  \
+        }                                                                                                                                                      \
+    };
+
+    template<typename T>
+    struct strip_arguments;
+
+    template<template<typename...> typename Template, typename... Args>
+    struct strip_arguments<Template<Args...>>
+    {
+        template<typename... Ts>
+        using type = Template<Ts...>;
+    };
+
+#define NOOP(...)
+#define ONLY(...) __VA_ARGS__
+#define FIRST(...) __VA_ARGS__ NOOP
+#define SECOND(...) ONLY
+
+#define TYPECLASS_FRIEND_MIXIN(x, typeclass_name, memfn_name)                                                                                                  \
+    template<typename Typeclass, typename ReturnType, typename... Args>                                                                                        \
+    friend struct CONCAT3(typeclass_name, _typeclass_erased_provide_, memfn_name);
+
+#define TYPECLASS_TYPE_BASE_CLASS(x, typeclass_info, memfn_name) TYPECLASS_TYPE_BASE_CLASS_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_TYPE_BASE_CLASS_IMPL(typeclass_name, template_args, memfn_name)                                                                              \
+private                                                                                                                                                        \
+    TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                       \
+        CONCAT3(typeclass_name, _typeclass_provide_, memfn_name),                                                                                              \
+        typeclass_name template_args>,
+
+#define TYPECLASS_TYPE_BASE_USING(x, typeclass_info, memfn_name) TYPECLASS_TYPE_BASE_USING_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_TYPE_BASE_USING_IMPL(typeclass_name, template_args, memfn_name)                                                                              \
+    using TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<                                                                                                        \
+        typename CONCAT(typeclass_name, _definition)                                                                                                           \
+            template_args::memfn_name, /*reaver::strip_arguments<CONCAT3(typeclass_name, _typeclass_provide_, memfn_name)>::template type,*/                   \
+        CONCAT3(typeclass_name, _typeclass_provide_, memfn_name),                                                                                              \
+        typeclass_name template_args>::memfn_name;
+
+#define TYPECLASS_BASE_BASE_CLASS(x, typeclass_info, memfn_name) TYPECLASS_BASE_BASE_CLASS_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_BASE_BASE_CLASS_IMPL(typeclass_name, template_args, memfn_name)                                                                              \
+public                                                                                                                                                         \
+    virtual TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                               \
+        CONCAT3(typeclass_name, _typeclass_base_provide_, memfn_name)>,
+
+#define TYPECLASS_IMPL_BASE_CLASS(x, typeclass_info, memfn_name) TYPECLASS_IMPL_BASE_CLASS_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_IMPL_BASE_CLASS_IMPL(typeclass_name, template_args, memfn_name)                                                                              \
+public                                                                                                                                                         \
+    TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                       \
+        CONCAT3(typeclass_name, _typeclass_impl_provide_, memfn_name),                                                                                         \
+        typeclass_name template_args,                                                                                                                          \
+        TYPECLASS_T>,
+
+#define TYPECLASS_IMPL_CTOR_INIT(x, typeclass_info, memfn_name) TYPECLASS_IMPL_CTOR_INIT_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_IMPL_CTOR_INIT_IMPL(typeclass_name, template_args, memfn_name)                                                                               \
+    TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                       \
+        CONCAT3(typeclass_name, _typeclass_impl_provide_, memfn_name),                                                                                         \
+        typeclass_name template_args,                                                                                                                          \
+        TYPECLASS_T>{ t },
+
+#define TYPECLASS_ERASED_BASE_CLASS(x, typeclass_info, memfn_name) TYPECLASS_ERASED_BASE_CLASS_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_ERASED_BASE_CLASS_IMPL(typeclass_name, template_args, memfn_name)                                                                            \
+protected                                                                                                                                                      \
+    TYPECLASS_INTERNAL_REAVER_NAMESPACE::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                       \
+        CONCAT3(typeclass_name, _typeclass_erased_provide_, memfn_name),                                                                                       \
+        typeclass_name template_args>,
+
+#define TYPECLASS_ERASED_USING(x, typeclass_info, memfn_name) TYPECLASS_ERASED_USING_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_ERASED_USING_IMPL(typeclass_name, template_args, memfn_name)                                                                                 \
+    using CONCAT(base_, memfn_name) = reaver::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                  \
+        CONCAT3(typeclass_name, _typeclass_erased_provide_, memfn_name),                                                                                       \
+        typeclass_name template_args>;                                                                                                                         \
+    using CONCAT(base_, memfn_name)::memfn_name;
+
+#define DEFINE_TYPECLASS_SEQ(template_decl, template_args, typeclass_name, member_list)                                                                        \
+    BOOST_PP_SEQ_FOR_EACH(TYPECLASS_PREPARE_MIXINS, typeclass_name, member_list)                                                                               \
+                                                                                                                                                               \
+    template_decl struct typeclass_name : BOOST_PP_SEQ_FOR_EACH(TYPECLASS_TYPE_BASE_CLASS, (typeclass_name)(template_args), member_list)                       \
+                                              TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<typeclass_name template_args>                                  \
+    {                                                                                                                                                          \
+        TYPECLASS_INSTANCE(typename TYPECLASS_INSTANCE_ARGUMENT);                                                                                              \
+        class erased_ref;                                                                                                                                      \
+        class erased;                                                                                                                                          \
+                                                                                                                                                               \
+        BOOST_PP_SEQ_FOR_EACH(TYPECLASS_FRIEND_MIXIN, typeclass_name, member_list)                                                                             \
+        BOOST_PP_SEQ_FOR_EACH(TYPECLASS_TYPE_BASE_USING, (typeclass_name)(template_args), member_list)                                                         \
+                                                                                                                                                               \
+        struct _base : BOOST_PP_SEQ_FOR_EACH(TYPECLASS_BASE_BASE_CLASS,                                                                                        \
+                           (typeclass_name)(template_args),                                                                                                    \
+                           member_list) TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<_base>                                                               \
+        {                                                                                                                                                      \
+            virtual ~_base() = default;                                                                                                                        \
+            virtual std::unique_ptr<_base> clone() const = 0;                                                                                                  \
+        };                                                                                                                                                     \
+                                                                                                                                                               \
+    private:                                                                                                                                                   \
+        template<typename TYPECLASS_T>                                                                                                                         \
+        struct _impl : _base,                                                                                                                                  \
+                       BOOST_PP_SEQ_FOR_EACH(TYPECLASS_IMPL_BASE_CLASS,                                                                                        \
+                           (typeclass_name)(template_args),                                                                                                    \
+                           member_list) TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<_impl<TYPECLASS_T>>                                                  \
+        {                                                                                                                                                      \
+            _impl(TYPECLASS_T t)                                                                                                                               \
+                : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<TYPECLASS_T>{ std::forward<TYPECLASS_T>(t) },                             \
+                  BOOST_PP_SEQ_FOR_EACH(TYPECLASS_IMPL_CTOR_INIT,                                                                                              \
+                      (typeclass_name)(template_args),                                                                                                         \
+                      member_list) TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<_impl<TYPECLASS_T>>{}                                                     \
+            {                                                                                                                                                  \
+            }                                                                                                                                                  \
+                                                                                                                                                               \
+            virtual std::unique_ptr<_base> clone() const override                                                                                              \
+            {                                                                                                                                                  \
+                return std::make_unique<_impl>(TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<TYPECLASS_T>::t);                            \
+            }                                                                                                                                                  \
+        };                                                                                                                                                     \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template_decl class typeclass_name template_args::erased_ref                                                                                               \
+        : public typeclass_name,                                                                                                                               \
+          BOOST_PP_SEQ_FOR_EACH(TYPECLASS_ERASED_BASE_CLASS, (typeclass_name)(template_args), member_list)                                                     \
+              TYPECLASS_INTERNAL_REAVER_NAMESPACE::virtual_dtor<typeclass_name::erased>                                                                        \
+    {                                                                                                                                                          \
+    public:                                                                                                                                                    \
+        template<typename TYPECLASS_T>                                                                                                                         \
+        erased_ref(std::reference_wrapper<TYPECLASS_T> t)                                                                                                      \
+            : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>{                                      \
+                  std::make_unique<_impl<TYPECLASS_T &>>(t.get())                                                                                              \
+              }                                                                                                                                                \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+                                                                                                                                                               \
+        template<typename TYPECLASS_T>                                                                                                                         \
+        erased_ref(TYPECLASS_T & t)                                                                                                                            \
+            : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>{                                      \
+                  std::make_unique<_impl<TYPECLASS_T &>>(t)                                                                                                    \
+              }                                                                                                                                                \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+                                                                                                                                                               \
+        erased_ref(const erased_ref & other)                                                                                                                   \
+            : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>{                                      \
+                  other.TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>::t->clone()                 \
+              }                                                                                                                                                \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+                                                                                                                                                               \
+    protected:                                                                                                                                                 \
+        erased_ref() = default;                                                                                                                                \
+                                                                                                                                                               \
+    public:                                                                                                                                                    \
+        BOOST_PP_SEQ_FOR_EACH(TYPECLASS_ERASED_USING, (typeclass_name)(template_args), member_list)                                                            \
+    };                                                                                                                                                         \
+                                                                                                                                                               \
+    template_decl class typeclass_name template_args::erased : public typeclass_name::erased_ref                                                               \
+    {                                                                                                                                                          \
+    public:                                                                                                                                                    \
+        template<typename TYPECLASS_T>                                                                                                                         \
+        erased(TYPECLASS_T && t)                                                                                                                               \
+            : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>{                                      \
+                  std::make_unique<_impl<std::remove_reference_t<TYPECLASS_T>>>(std::forward<TYPECLASS_T>(t))                                                  \
+              }                                                                                                                                                \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+                                                                                                                                                               \
+        template<typename TYPECLASS_T>                                                                                                                         \
+        erased(std::reference_wrapper<TYPECLASS_T> t)                                                                                                          \
+            : TYPECLASS_INTERNAL_REAVER_NAMESPACE::typeclass_provide_data_member<std::unique_ptr<typeclass_name::_base>>{                                      \
+                  std::make_unique<_impl<TYPECLASS_T &>>(t.get())                                                                                              \
+              }                                                                                                                                                \
+        {                                                                                                                                                      \
+        }                                                                                                                                                      \
+    };
+
+#define TYPECLASS_ERASED_INSTANCE_BASE(x, typeclass_name, memfn_name)                                                                                          \
+public                                                                                                                                                         \
+    ::reaver::                                                                                                                                                 \
+        explode<CONCAT(typeclass_name, _definition)::memfn_name, CONCAT3(typeclass_name, _typeclass_erased_instance_provide_, memfn_name), typeclass_name>,
+
+#define TYPECLASS_ERASED_INSTANCE_TEMPLATE_BASE(x, typeclass_info, memfn_name)                                                                                 \
+    TYPECLASS_ERASED_INSTANCE_TEMPLATE_BASE_IMPL(FIRST typeclass_info, SECOND typeclass_info, memfn_name)
+#define TYPECLASS_ERASED_INSTANCE_TEMPLATE_BASE_IMPL(typeclass_name, template_args, memfn_name)                                                                \
+public                                                                                                                                                         \
+    ::reaver::explode<typename CONCAT(typeclass_name, _definition) template_args::memfn_name,                                                                  \
+        CONCAT3(typeclass_name, _typeclass_erased_instance_provide_, memfn_name),                                                                              \
+        typeclass_name template_args>,
+
+#define DEFINE_TYPECLASS_IMPL(typeclass_name, member_list)                                                                                                     \
+    DEFINE_TYPECLASS_SEQ(, , typeclass_name, member_list)                                                                                                      \
+    template<>                                                                                                                                                 \
+    struct typeclass_name::instance<typeclass_name, typeclass_name::erased_ref>                                                                                \
+        : BOOST_PP_SEQ_FOR_EACH(TYPECLASS_ERASED_INSTANCE_BASE, typeclass_name, member_list)::reaver::unit                                                     \
+    {                                                                                                                                                          \
+    };                                                                                                                                                         \
+    template<>                                                                                                                                                 \
+    struct typeclass_name::instance<typeclass_name, typeclass_name::erased> : typeclass_name::instance<typeclass_name, typeclass_name::erased_ref>             \
+    {                                                                                                                                                          \
+    }
+
+#define DEFINE_TYPECLASS(typeclass_name, ...) DEFINE_TYPECLASS_IMPL(typeclass_name, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+#define TYPECLASS_TEMPLATE_DECL(X) template<X>
+#define TYPECLASS_TEMPLATE_ARGS(X) <X>
+
+#define DEFINE_TYPECLASS_TEMPLATE_IMPL(template_decl, template_args, typeclass_name, member_list)                                                              \
+    DEFINE_TYPECLASS_SEQ(TYPECLASS_TEMPLATE_DECL template_decl, TYPECLASS_TEMPLATE_ARGS template_args, typeclass_name, member_list)                            \
+    TYPECLASS_TEMPLATE_DECL template_decl struct typeclass_instance_helper<typeclass_name TYPECLASS_TEMPLATE_ARGS template_args,                               \
+        typename typeclass_name TYPECLASS_TEMPLATE_ARGS template_args::erased_ref>                                                                             \
+        : BOOST_PP_SEQ_FOR_EACH(TYPECLASS_ERASED_INSTANCE_TEMPLATE_BASE, (typeclass_name)(TYPECLASS_TEMPLATE_ARGS template_args), member_list)::reaver::unit   \
+    {                                                                                                                                                          \
+    };                                                                                                                                                         \
+    TYPECLASS_TEMPLATE_DECL template_decl struct typeclass_instance_helper<typeclass_name TYPECLASS_TEMPLATE_ARGS template_args,                               \
+        typename typeclass_name TYPECLASS_TEMPLATE_ARGS template_args::erased>                                                                                 \
+        : typeclass_instance_helper<typeclass_name TYPECLASS_TEMPLATE_ARGS template_args,                                                                      \
+              typename typeclass_name TYPECLASS_TEMPLATE_ARGS template_args::erased_ref>                                                                       \
+    {                                                                                                                                                          \
+    };
+
+#define DEFINE_TYPECLASS_TEMPLATE(template_decl, template_args, typeclass_name, ...)                                                                           \
+    INSTANCE_TEMPLATE_HELPER;                                                                                                                                  \
+    DEFINE_TYPECLASS_TEMPLATE_IMPL(template_decl, template_args, typeclass_name, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+}
+}

--- a/tests/typeclass/typeclass.cpp
+++ b/tests/typeclass/typeclass.cpp
@@ -1,0 +1,189 @@
+/**
+ * Reaver Library Licence
+ *
+ * Copyright © 2017 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#include "typeclass/typeclass.h"
+
+#include <reaver/function.h>
+
+#include <reaver/mayfly.h>
+
+MAYFLY_BEGIN_SUITE("typeclass");
+
+struct counter_definition
+{
+    using increment = void();
+    using get_value = int();
+};
+
+DEFINE_TYPECLASS(counter, increment, get_value);
+
+// clang-format off
+DEFAULT_INSTANCE(counter, T)
+{
+    static void increment(T & t)
+    {
+        ++t;
+    }
+
+    static int get_value(T & t)
+    {
+        return t.get_value();
+    }
+};
+// clang-format on
+
+class simple_counter : public counter
+{
+public:
+    simple_counter & operator++()
+    {
+        ++_value;
+        return *this;
+    }
+
+    int get_value() const
+    {
+        return _value;
+    }
+
+private:
+    std::uintmax_t _value = 0;
+};
+
+MAYFLY_ADD_TESTCASE("default implementation", [] {
+    simple_counter some_counter;
+    MAYFLY_REQUIRE(counter::get_value(some_counter) == 0);
+    counter::increment(some_counter);
+    MAYFLY_REQUIRE(counter::get_value(some_counter) == 1);
+});
+
+MAYFLY_ADD_TESTCASE("erased", [] {
+    simple_counter some_counter;
+
+    counter::erased erased = some_counter;
+    counter::erased_ref erased_ref = some_counter;
+
+    counter::increment(some_counter);
+    counter::increment(erased);
+    counter::increment(erased_ref);
+
+    MAYFLY_REQUIRE(counter::get_value(erased) == 1);
+    MAYFLY_REQUIRE(counter::get_value(erased_ref) == 2);
+    MAYFLY_REQUIRE(counter::get_value(some_counter) == 2);
+});
+
+class broken_counter
+{
+public:
+    TYPECLASS_INSTANCE(typename T);
+
+    int get_value() const
+    {
+        return 123;
+    }
+};
+
+// clang-format off
+INSTANCE(counter, broken_counter)
+{
+    static void increment(broken_counter &)
+    {
+        throw 1;
+    }
+};
+// clang-format on
+
+MAYFLY_ADD_TESTCASE("overriden implementation", [] {
+    broken_counter some_counter;
+    MAYFLY_REQUIRE(counter::get_value(some_counter) == 123);
+    MAYFLY_REQUIRE_THROWS_TYPE(int, counter::increment(some_counter));
+    MAYFLY_REQUIRE(counter::get_value(some_counter) == 123);
+});
+
+template<typename T>
+struct sizeof_counter_definition
+{
+    using increment = void();
+    using get_value = int();
+};
+
+DEFINE_TYPECLASS_TEMPLATE((typename T), (T), sizeof_counter, increment, get_value);
+
+// clang-format off
+DEFAULT_INSTANCE_TEMPLATE((typename T), (T), sizeof_counter, U)
+{
+    static void increment(U & u)
+    {
+        ++u;
+    }
+
+    static int get_value(U & u)
+    {
+        return u.get_value();
+    }
+};
+// clang-format on
+
+template<typename T>
+struct some_sizeof_counter : sizeof_counter<T>
+{
+    TYPECLASS_INSTANCE_TEMPLATE((typename U), (U), some_sizeof_counter);
+
+    void increment()
+    {
+        _value += sizeof(T);
+    }
+
+    int get_value() const
+    {
+        return _value;
+    }
+
+private:
+    int _value = 0;
+};
+
+// clang-format off
+INSTANCE_TEMPLATE((typename T), (T), sizeof_counter, some_sizeof_counter<T>)
+{
+    static void increment(some_sizeof_counter<T> & t)
+    {
+        t.increment();
+    }
+};
+// clang-format on
+
+MAYFLY_ADD_TESTCASE("typeclass template", [] {
+    some_sizeof_counter<int> some_counter;
+    MAYFLY_REQUIRE(sizeof_counter<int>::get_value(some_counter) == 0);
+    sizeof_counter<int>::increment(some_counter);
+    MAYFLY_REQUIRE(sizeof_counter<int>::get_value(some_counter) == sizeof(int));
+
+    sizeof_counter<int>::erased erased = some_counter;
+    sizeof_counter<int>::erased_ref erased_ref = some_counter;
+
+    sizeof_counter<int>::increment(some_counter);
+    MAYFLY_REQUIRE(sizeof_counter<int>::get_value(erased) == sizeof(int));
+    MAYFLY_REQUIRE(sizeof_counter<int>::get_value(erased_ref) == sizeof(int) * 2);
+});
+
+MAYFLY_END_SUITE;


### PR DESCRIPTION
Rough TODO for the future:
* SFINAEable typeclass instances (even for non-templated typeclasses)
* honor cvref qualifiers on member declarations
* allow overloads of member functions (possibly with tpl::vector)
* add checking for instance exhaustiveness, i.e. whether all functions
   are implemented (not 100% sure how to do this)
* support typeclass hierarchies
* allocation policies for `erased`
* possibly "vtable policies" like Louis Dionne's `te`'s?
* reflection-powered version of the library (this one requires a
   working reflection implementation (duh))
* generation of language concepts for the typeclasses