### PR TITLE
This header wasn't needed.

### DIFF
--- a/include/reaver/configuration/options.h
+++ b/include/reaver/configuration/options.h
@@ -29,7 +29,6 @@
 
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
-#include <boost/range/algorithm.hpp>
 
 #include "../configuration.h"
 #include "../exception.h"

--- a/tests/options.cpp
+++ b/tests/options.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/functional/hash.hpp>
 #include <boost/program_options.hpp>
-#include <boost/range/algorithm.hpp>
 
 namespace test
 {


### PR DESCRIPTION
Also it craps itself with C++17-compliant stdlibs.