### PR TITLE
prelude: fix the nestedness of inline namespaces.

### DIFF
--- a/include/reaver/prelude/fold.h
+++ b/include/reaver/prelude/fold.h
@@ -1,7 +1,7 @@
 /**
  * Reaver Library Licence
  *
- * Copyright © 2015 Michał "Griwes" Dominiak
+ * Copyright © 2015, 2018 Michał "Griwes" Dominiak
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -28,9 +28,9 @@
 
 namespace reaver
 {
-inline namespace prelude
+inline namespace _v1
 {
-    inline namespace _v1
+    inline namespace prelude
     {
         template<typename F, typename T>
         inline constexpr auto foldr(F &&, T && t)

--- a/include/reaver/prelude/functor.h
+++ b/include/reaver/prelude/functor.h
@@ -1,7 +1,7 @@
 /**
  * Reaver Library Licence
  *
- * Copyright © 2015-2017 Michał "Griwes" Dominiak
+ * Copyright © 2015-2018 Michał "Griwes" Dominiak
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -33,11 +33,11 @@
 
 namespace reaver
 {
-inline namespace prelude
+inline namespace _v1
 {
-    inline namespace functor
+    inline namespace prelude
     {
-        inline namespace _v1
+        inline namespace functor
         {
             template<typename T,
                 typename F,

--- a/include/reaver/prelude/monad.h
+++ b/include/reaver/prelude/monad.h
@@ -1,7 +1,7 @@
 /**
  * Reaver Library Licence
  *
- * Copyright © 2016 Michał "Griwes" Dominiak
+ * Copyright © 2016, 2018 Michał "Griwes" Dominiak
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages
@@ -26,11 +26,11 @@
 
 namespace reaver
 {
-inline namespace prelude
+inline namespace _v1
 {
-    inline namespace monad
+    inline namespace prelude
     {
-        inline namespace _v1
+        inline namespace monad
         {
             template<typename Vector,
                 typename std::enable_if<is_vector<std::remove_cv_t<std::remove_reference_t<Vector>>>::value


### PR DESCRIPTION
This is indeed an error, but only GCC 8.1 catches it so far.